### PR TITLE
Sort IE11 compatibility issues

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -20,7 +20,7 @@ function toggleDisplayGenerator(id) {
 
 window.addEventListener(
     "load", 
-    ()=>{
+    function () {
         document.getElementById("");
         console.log("test"); 
         document.getElementById("year").innerHTML = new Date().getFullYear();


### PR DESCRIPTION
IE11 doesn't support arrow functions, so without running a build chain to compile it down to ES5 this won't work