### PR TITLE
Ok now it is fixed

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -20,7 +20,7 @@
     <script src="https://kit.fontawesome.com/fc2cc31544.js" crossorigin="anonymous"></script>
 </head>
 <body>
-    <header include-html="header.html"></header>
+    <header include-html="header.html" loadCB="headerLoadCB"></header>
     <article class="primary form-background">
         <div id="contact-wrapper" class="wrapper">
             <section id="contact" class="grid container">
@@ -55,7 +55,7 @@
             </section>
         </div>
     </article>
-    <footer include-html="footer.html" class="primary"></footer>
+    <footer include-html="footer.html" loadCB="footerLoadCB" class="primary"></footer>
     <script>
         includeHTML();
     </script>

--- a/gallery.html
+++ b/gallery.html
@@ -22,7 +22,7 @@
             You are missing out on many features of this site through not having it enabled.</em>
         </div>
     </noscript>
-    <header include-html="header.html"></header>
+    <header include-html="header.html" loadCB="headerLoadCB"></header>
     <article>
         <section class="banner container full primary">
             <div class="container">
@@ -67,7 +67,7 @@
             </a>
         </section>
     </article>
-    <footer include-html="footer.html" class="primary"></footer>
+    <footer include-html="footer.html" loadCB="footerLoadCB" class="primary"></footer>
     <script>
         includeHTML();
     </script>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <noscript class="no-js"></noscript>
 
     <!-- <div class="content-wrapper"> -->
-    <header include-html="header.html"></header>
+    <header include-html="header.html" loadCB="headerLoadCB"></header>
     <article>
         <section class="banner container full primary">
             <div class="container">
@@ -57,7 +57,7 @@
         </section>
     </article>
     <!-- </div> -->
-    <footer include-html="footer.html" class="primary"></footer>
+    <footer include-html="footer.html" loadCB="footerLoadCB" class="primary"></footer>
     <script>
         includeHTML();
     </script>

--- a/scripts/includeHTML.js
+++ b/scripts/includeHTML.js
@@ -1,5 +1,5 @@
-function includeHTML() {
-    var z, i, elmnt, file, xhttp;
+const includeHTML = function() {
+    var z, i, elmnt, file;
     /* Loop through a collection of all HTML elements: */
     z = document.querySelectorAll("[include-html]");
     for (i = 0; i < z.length; i++) {
@@ -7,7 +7,7 @@ function includeHTML() {
         /*search for elements with a certain atrribute:*/
         file = elmnt.getAttribute("include-html");
         if (file) {
-            writeFromFile(elmnt,file);
+            writeFromFile(elmnt,file,i);
         }
     }
 }
@@ -21,22 +21,82 @@ var headerLoadCB = function() {
     navToggle.addEventListener("click", toggleDisplayGenerator("main-nav"));
 }
 
-function writeFromFile(elmnt,file) {
-    /* Make an HTTP request using the attribute value as the file name: */
-    xhttp = new XMLHttpRequest();
-    xhttp.onreadystatechange = function() {
-        if (this.readyState == 4) {
-            if (this.status == 200) {elmnt.innerHTML = this.responseText;}
-            if (this.status == 404) {elmnt.innerHTML = "Page not found.";}
-            elmnt.removeAttribute("include-html");
-            let loadCB = elmnt.getAttribute("loadCB");
-            if (loadCB && window[loadCB]) {
-                window[loadCB]();
-                elmnt.removeAttribute("loadCB");
-            }
-        }
-    }
-    xhttp.open("GET", file, true);
-    xhttp.send();
+const handleRejectedPromise = function(err, ...args) {
+    console.log("Rejected");
+    console.log(args);
+    alert("Oops! Something went wrong. Some features may not functional at the moment\nmessage: " + err);
+
 }
 
+
+const writeFromFile = function(elmnt, file, promiseId) {
+
+    /* Make an HTTP request using the attribute value as the file name: */
+    // (new Promise(loadElementExecutor(handleLoadFulfilled, handleRejectedPromise)))
+
+    console.log("promise " + promiseId + " being created");
+    //creates an array of promises for each element with a [include-html] attribute 
+    promiseHTMLContent(elmnt, file, promiseId)
+    //load the html content
+    .then(loadHTMLContent.bind(null, elmnt, promiseId))
+    //add functionality
+    .then(loadFunctionality.bind(null, elmnt, promiseId))
+    //error
+    .catch(handleRejectedPromise.bind(null, elmnt, file, promiseId));
+}
+
+
+
+
+
+const promiseHTMLContent = function(elmnt, file, promiseId) {
+    elmnt.removeAttribute("include-html");
+    console.log("promise " + promiseId + " created");
+    return new Promise((resolve, reject) => {
+        xhttp = new XMLHttpRequest();
+        xhttp.onreadystatechange = function() {
+            if (this.readyState == 4) {
+                if (this.status == 200) {
+                    resolve(this.responseText);
+                    console.log("HTTP request " + promiseId + " finished");
+                }
+                if (this.status == 404) {
+                    reject("404 - Resource not found.")
+                    console.log("HTTP request " + promiseId + " failed");
+                }
+            }
+        }
+        xhttp.open("GET", file, true);
+        xhttp.send();
+        console.log("HTTP request " + promiseId + " sent");
+    })
+}
+
+const loadHTMLContent = function(elmnt, promiseId, HTMLcontent) {
+    console.log("HTML content " + promiseId + " loading");
+    elmnt.innerHTML = HTMLcontent;
+}
+
+const loadFunctionality = function(elmnt, promiseId) {
+    let loadCB = elmnt.getAttribute("loadcb");
+    console.log("HTML functionality " + promiseId + " loading - " + loadCB);
+    if (loadCB && window[loadCB]) {
+        window[loadCB]();
+        elmnt.removeAttribute("loadCB");
+    }
+}
+
+
+
+// for debugging in console:
+/*
+[...document.querySelectorAll("[include-html]")].map((el)=>{return promiseHTMLContent(el, file)});
+//runs the promises
+Promise.all(myPromises)
+//load the html content
+.then(loadHTMLContent)
+//add functionality
+.then(loadFunctionality)
+//error
+.catch(handleRejectedPromise);
+*/


### PR DESCRIPTION
To utilise the inclusion functionality the following attribute-value pairs in conjuction with respective scripts/html content are to be used: include-html and loadCB.

Example:
<header include-html="header.html" loadCB="headerLoadCB"></header>